### PR TITLE
fix: use user-writable cache dir for opcodes pickle file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         ]
     },
     install_requires=[
+        'appdirs',
         'lark-parser>=0.7.8',
         'pyyaml>=6.0.0'
     ],

--- a/sfzlint/spec.py
+++ b/sfzlint/spec.py
@@ -5,6 +5,7 @@ import pickle
 from functools import lru_cache
 from pathlib import Path
 from numbers import Real  # int or float
+import appdirs
 import yaml
 from . import validators
 
@@ -198,9 +199,11 @@ def _validator(data_value):
 
 
 def _pickled(name, fn):
-    p_file = Path(__file__).parent / f'{name}.pickle'
+    user_cache_dir = Path(appdirs.user_cache_dir("sfzlint", "jisaacstone"))
+    p_file = user_cache_dir / f'{name}.pickle'
     if not p_file.exists():
         data = fn()
+        user_cache_dir.mkdir(parents=True, exist_ok=True)
         with p_file.open('wb') as fob:
             pickle.dump(data, fob)
     else:
@@ -210,5 +213,5 @@ def _pickled(name, fn):
 
 
 # pickling as cache cuts script time by ~400ms on my system
-opcodes = _pickled('opcides', lambda: _override(_extract()))
+opcodes = _pickled('opcodes', lambda: _override(_extract()))
 cc_opcodes = {k for k in opcodes if 'cc' in k and 'curvecc' not in k}


### PR DESCRIPTION
Also fixes a typo in the name of the pickle file ("opcides" -> "opcodes").

Without this fix, if you install sfzlint into the system-wide site-packages directory, you'll get an permission error when sfzlint tries to write the cache pickle file:

	PermissionError: [Errno 13] Permission denied: '/usr/lib/python3.10/site-packages/sfzlint/opcides.pickle'

This fix adds the [appdirs](https://pypi.org/project/appdirs/) package as a dependency and uses it to determine the appropriate user-writable cache dir and write the cache pickle file there.

Full traceback:

```
Traceback (most recent call last):
  File "/usr/bin/sfzlint", line 33, in <module>
    sys.exit(load_entry_point('sfzlint==0.1.2', 'console_scripts', 'sfzlint')())
  File "/usr/bin/sfzlint", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 162, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/lib/python3.10/site-packages/sfzlint/cli.py", line 5, in <module>
    from . import spec, parser, lint, opcodes
  File "/usr/lib/python3.10/site-packages/sfzlint/spec.py", line 213, in <module>
    opcodes = _pickled('opcides', lambda: _override(_extract()))
  File "/usr/lib/python3.10/site-packages/sfzlint/spec.py", line 204, in _pickled
    with p_file.open('wb') as fob:
  File "/usr/lib/python3.10/pathlib.py", line 1117, in open
    return self._accessor.open(self, mode, buffering, encoding, errors,
PermissionError: [Errno 13] Permission denied: '/usr/lib/python3.10/site-packages/sfzlint/opcides.pickle'
```
