### PR TITLE
Install using GitHub secure url

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To fix this run with `--rel-path`
 I've not put this on pypi yet. You can install with pip
 
     pip install pyyaml
-    pip install git+git://github.com/jisaacstone/sfzlint.git
+    pip install git+https://github.com/jisaacstone/sfzlint.git
 
 Or clone the repo and use `python setup.py install`
 


### PR DESCRIPTION
When running:
`pip install git+git://github.com/jisaacstone/sfzlint.git`

You get the error:
```
fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

March 15, 2022 changes were made to GitHub urls
Users connecting via SSH or git:// are affected. Updating to https resolves the issue
https://github.blog/2021-09-01-improving-git-protocol-security-github/